### PR TITLE
Replace pypy py27 builds with pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
-  - "pypy"
+  - "pypy3"
 matrix:
   include:
     - python: 3.8


### PR DESCRIPTION
As Python 2.7 is EOL Jan 1, 2020, replace the pypy for Python 2.7 Travis CI build with pypy3.